### PR TITLE
fix(archive): use commit_hash, not tar SHA, for change detection

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -286,18 +286,22 @@ jobs:
       - name: Check for changes from previous archive
         if: steps.validate.outputs.valid == 'true'
         id: check_changes
+        env:
+          OWNER: ${{ steps.parse.outputs.owner }}
+          REPO: ${{ steps.parse.outputs.repo }}
+          NEW_COMMIT: ${{ steps.clone.outputs.commit_hash }}
+          NEW_ARCHIVE_HASH: ${{ steps.archive.outputs.archive_hash }}
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          OWNER="${{ steps.parse.outputs.owner }}"
-          REPO="${{ steps.parse.outputs.repo }}"
-          NEW_HASH="${{ steps.archive.outputs.archive_hash }}"
-
-          echo "New archive hash: $NEW_HASH"
+          echo "New commit:       $NEW_COMMIT"
+          echo "New archive hash: $NEW_ARCHIVE_HASH"
 
           # Get all releases for this repo
           RELEASES=$(curl -s \
             -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/releases?per_page=100")
+            -H "Authorization: token $GH_TOKEN" \
+            "https://api.github.com/repos/$GH_REPOSITORY/releases?per_page=100")
 
           # Find the most recent release for this owner/repo
           PREV_TAG=$(echo "$RELEASES" | jq -r --arg prefix "${OWNER}__${REPO}__" '
@@ -312,25 +316,43 @@ jobs:
 
           echo "Previous release tag: $PREV_TAG"
 
-          # Get previous metadata to compare hash
-          PREV_METADATA_URL="https://github.com/${{ github.repository }}/releases/download/$PREV_TAG/metadata.json"
-          PREV_HASH=$(curl -sL "$PREV_METADATA_URL" | jq -r '.archive_hash // empty')
+          # Read previous metadata.json once so we can compare commit_hash
+          # (the source-of-truth signal) and fall back to archive_hash for
+          # legacy releases created before commit_hash was persisted.
+          PREV_METADATA_URL="https://github.com/$GH_REPOSITORY/releases/download/$PREV_TAG/metadata.json"
+          PREV_METADATA=$(curl -sL "$PREV_METADATA_URL")
+          PREV_COMMIT=$(echo "$PREV_METADATA" | jq -r '.commit_hash // empty')
+          PREV_ARCHIVE_HASH=$(echo "$PREV_METADATA" | jq -r '.archive_hash // empty')
 
-          if [ -z "$PREV_HASH" ]; then
+          # Prefer commit_hash: it changes iff source changed. archive_hash
+          # is non-deterministic across runs (gzip mtime + .git/ contents),
+          # which is why the old comparison created a release every cron tick.
+          if [ -n "$PREV_COMMIT" ] && [ -n "$NEW_COMMIT" ]; then
+            echo "Previous commit:  $PREV_COMMIT"
+            if [ "$NEW_COMMIT" == "$PREV_COMMIT" ]; then
+              echo "Commit unchanged - skipping release"
+              echo "has_changes=false" >> $GITHUB_OUTPUT
+            else
+              echo "Commit changed - will create new release"
+              echo "has_changes=true" >> $GITHUB_OUTPUT
+            fi
+            exit 0
+          fi
+
+          # Legacy fallback: previous release pre-dates commit_hash persistence.
+          # archive_hash is not reliable for change detection, so on first
+          # encounter we treat this as "changed" to force one fresh release
+          # whose metadata will include commit_hash; subsequent runs use the
+          # commit_hash path above.
+          if [ -z "$PREV_ARCHIVE_HASH" ]; then
             echo "No previous hash found - will create new release"
             echo "has_changes=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          echo "Previous archive hash: $PREV_HASH"
-
-          if [ "$NEW_HASH" == "$PREV_HASH" ]; then
-            echo "Archive hash unchanged - skipping release"
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-          else
-            echo "Archive hash changed - will create new release"
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-          fi
+          echo "Previous archive hash: $PREV_ARCHIVE_HASH (legacy, no commit_hash)"
+          echo "Forcing new release to record commit_hash going forward"
+          echo "has_changes=true" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
         if: steps.validate.outputs.valid == 'true' && steps.check_changes.outputs.has_changes == 'true'


### PR DESCRIPTION
## Summary

Fixes the bug that caused **478 unnecessary releases** to accumulate on this repo (only ~5 of which represented actual upstream changes).

The `Check for changes from previous archive` step in `archive.yml` was gating new releases on `sha256(archive.tar.gz) != previous_sha256`. That comparison is broken because the new hash is non-deterministic across runs:

1. **`.git/` is included in the tar** — every shallow clone produces a fresh `.git/` (different pack timestamps, different `FETCH_HEAD`, sometimes different pack composition), so the tar bytes differ even when the source is identical.
2. **`tar -czf` invokes gzip without `-n`** — gzip embeds the current mtime in its header, so even bit-identical tar input produces different gzip bytes every run.

Net effect: `has_changes=true` every run → daily cron created 1 release per active repo per day, forever.

## Fix

Compare `commit_hash` (already captured by `git rev-parse HEAD` at the clone step, and already written into `metadata.json` — it just was never read back) instead of `archive_hash`. `commit_hash` changes iff the source actually changed; that's the right signal.

`archive_hash` stays in `metadata.json` for asset-integrity reference and as a legacy fallback path: previous releases pre-date `commit_hash` persistence, so on first encounter we treat them as "changed" once to record a fresh `commit_hash`; subsequent runs use the commit comparison.

Also: moved the step's inline `${{ }}` interpolations into `env:` per the workflow-injection hardening guidance — none of these values are user-controlled today, but it's the safer default for future edits.

## Test plan

- [x] YAML parses (validated with `ruby -r yaml`)
- [ ] Manual `workflow_dispatch` run of `archive.yml` against a repo whose `commit_hash` is unchanged since a recent (post-merge) archive → expect `Commit unchanged - skipping release` log line and **no** new release
- [ ] Manual `workflow_dispatch` against a repo with a fresh upstream commit → expect `Commit changed - will create new release` and a new release tag
- [ ] Re-enable the `Update Existing Archives` cron (currently disabled) and confirm the next scheduled run creates zero spurious releases when no upstream repos have changed

## Context

The 478 pre-existing releases were deleted manually before this PR (with `--cleanup-tag`); only the `index` release remains. After merge the `Update Existing Archives` workflow can be re-enabled safely (it is currently `disabled_manually`).

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation to enhance change detection accuracy and ensure proper release creation handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Technical-1/Git-Archiver-Web/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->